### PR TITLE
feat/generate-config-file-skeleton

### DIFF
--- a/gitlias/gitlias.go
+++ b/gitlias/gitlias.go
@@ -13,6 +13,22 @@ import (
 const scope = config.GlobalScope
 const configName = "gitlias.toml"
 
+const generateTemplate = `
+[alias]
+
+    [alias.personal]
+    user = ""
+    email = ""
+
+    [alias.work]
+    user = ""
+    email = ""
+`
+
+func Generate() string {
+	return generateTemplate
+}
+
 func List(configPath string) []string {
 	userConfig, err := Get(configPath)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ const configName = "gitlias.toml"
 
 var configPath string
 var listAliases bool
+var generateTemplate bool
 
 func init() {
 	defaultConf := func() string {
@@ -35,6 +36,7 @@ func init() {
 
 	flag.StringVar(&configPath, "config", defaultConf, "Configuration TOML file path")
 	flag.BoolVar(&listAliases, "list", false, "List current alias names in your configuration file")
+	flag.BoolVar(&generateTemplate, "generate", false, "Generate a simple configuration file")
 	flag.Parse()
 }
 
@@ -45,6 +47,12 @@ func main() {
 		for _, alias := range aliases {
 			fmt.Println(alias)
 		}
+		return
+	}
+
+	if generateTemplate {
+		output := gitlias.Generate()
+		fmt.Printf("%s", output)
 		return
 	}
 


### PR DESCRIPTION
Easily generate a configuration file using the `-generate` flag, this can then be redirected to a `~/gitlias.toml` file for modifying later.