### PR TITLE
redesign/list-flag

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -40,9 +40,9 @@ var addCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(addCmd)
 
-	addCmd.Flags().StringVar(&addUser, "user", "", "The username to make commits as, e.g. 'John Smith'")
-	addCmd.Flags().StringVar(&addEmail, "email", "", "The email to make commits as, e.g. 'john.smith@example.com'")
-	addCmd.Flags().StringVar(&addAlias, "alias", "", "A meaningful alias to give to this commit author")
+	addCmd.Flags().StringVar(&addUser, "user", "", "the username to make commits as, e.g. 'John Smith'")
+	addCmd.Flags().StringVar(&addEmail, "email", "", "the email to make commits as, e.g. 'john.smith@example.com'")
+	addCmd.Flags().StringVar(&addAlias, "alias", "", "meaningful alias to give to this commit author")
 
 	// Flags are required, this makes it far easier to parse the given values.
 	addCmd.MarkFlagRequired("user")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2022 Jack Dockerty jdockerty19@gmail.com
+*/
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jdockerty/gitlias/gitlias"
+	"github.com/spf13/cobra"
+)
+
+var current bool
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all configured aliases",
+	Long: `List all configured aliases within your configuration file.
+
+This can be modified using the --current flag to display the current active alias alone.
+
+For example:
+
+    gitlias list
+    gitlias list --current
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		aliases, currentAlias := gitlias.List(configPath)
+		if current {
+			fmt.Println(currentAlias)
+			return
+		}
+		s := strings.Join(aliases, "\n")
+		fmt.Println(s)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+
+	listCmd.Flags().BoolVar(&current, "current", false, "show only the active alias")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,6 @@ func init() {
 		return fmt.Sprintf("%s/%s", h, configName)
 	}()
 
-	rootCmd.PersistentFlags().StringVar(&configPath, "config", defaultConf, "Configuration file path")
-	rootCmd.Flags().BoolVar(&listAliases, "list", false, "List current aliases")
+	rootCmd.PersistentFlags().StringVar(&configPath, "config", defaultConf, "configuration file path")
+	rootCmd.Flags().BoolVar(&listAliases, "list", false, "list current aliases")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,9 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
-	"github.com/jdockerty/gitlias/gitlias"
 	"github.com/spf13/cobra"
 )
 
@@ -24,22 +22,9 @@ var rootCmd = &cobra.Command{
 	Use:   "gitlias",
 	Short: "Swap between your configured git aliases",
 	Long: `gitlias
+
 Swap between your configured git aliases, ensuring that you commit as the correct user.
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		listAlias, err := cmd.Flags().GetBool("list")
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-
-		if listAlias {
-			aliases, current := gitlias.List(configPath)
-			s := strings.Join(aliases, "\n")
-			fmt.Printf("%s\n\ncurrent: %s\n", s, current)
-			return
-		}
-	},
 }
 
 // Execute adds child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
Remove the list flag from root.go and add it as a sub command instead. This also removes the general text around the `--list` flag into a `--current` flag for the `list` sub command, so that only the current active alias is displayed.
